### PR TITLE
Tests / Allowed organelles when starting server

### DIFF
--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -6,6 +6,7 @@ process.env.CELL_MODE = process.env.CELL_MODE || '_test'
 var path = require('path')
 var chai = require('chai')
 var _ = require('lodash')
+var foldAndMerge = require('organic-dna-fold')
 
 global.expect = chai.expect
 
@@ -21,6 +22,73 @@ var variables = test.variables = {
 require('./clean-uploads')
 require('./uploads')
 
+/**
+ * Removes all organelles, from all processes' plasma and membrane's,
+ * which are not in the `allowedOrganelles` array (or object) and
+ * merges all values in `allowedOrganelles` object (if object)
+ *
+ * `allowedOrganelles` can be an array (in which case all allowed are kept as they are, merged with empty {})
+ * or an object (in which case all allowed organelles are merged with the object's value)
+ *
+ * Example:
+ * dna: `{ server.processes.plasma: { "A": { "foo": "bar" }, "B": {}, "C": {} } }`
+ * allowedOrganelles: `{ "A": { "foo": "baz" }, "B": {} }`
+ * result: `{ server.processes.plasma: { "A": { "foo": "baz" }, "B": {}, "C": false } }`
+ *
+ * Example with array:
+ * allowedOrganelles: `[ "A", "B" ]`
+ * result: `{ server.processes.plasma: { "A": { "foo": "bar" }, "B": {}, "C": false } }`
+ * @param dna
+ * @param allowedOrganelles
+ * @returns {*}
+ */
+function removeNotAllowedOrganelles (dna, allowedOrganelles) {
+  let allowedOrganellesObject = {}
+  if (Array.isArray(allowedOrganelles)) {
+    for (let i = 0; i < allowedOrganelles.length; i++) {
+      allowedOrganellesObject[allowedOrganelles[i]] = {}
+    }
+  } else if (typeof allowedOrganelles === 'object') {
+    allowedOrganellesObject = allowedOrganelles
+  } else {
+    throw new Error('allowedOrganelles must be either an object or an array')
+  }
+
+  for (let processName in dna.server.processes) {
+    if (dna.server.processes.hasOwnProperty(processName)) {
+      let process = dna.server.processes[processName]
+
+      mergeOnlyAllowed(process.plasma, allowedOrganellesObject)
+      mergeOnlyAllowed(process.membrane, allowedOrganellesObject)
+    }
+  }
+
+  return dna
+}
+
+/**
+ * Performs a `foldAndMerge` on the source branch,
+ * flagging all elements, not in `allowed`, as
+ * false (for removal) and merging `allowed`
+ *
+ * @param src
+ * @param allowed
+ */
+function mergeOnlyAllowed (src, allowed) {
+  let dst = {}
+  for (let srcKey in src) {
+    if (src.hasOwnProperty(srcKey)) {
+      if (Object.keys(allowed).includes(srcKey)) {
+        dst[srcKey] = allowed[srcKey]  // will be merged
+      } else {
+        dst[srcKey] = false  // will be removed
+      }
+    }
+  }
+
+  foldAndMerge(src, dst)
+}
+
 test.initTestEnv = function (done) {
   var loadDna = require('organic-dna-loader')
   loadDna(function (err, dna) {
@@ -32,7 +100,22 @@ test.initTestEnv = function (done) {
   })
 }
 
-test.startServer = function (next) {
+/**
+ * Starts the default server cell, with all organelles
+ * unless `allowedOrganelles` is provided.
+ * If `allowedOrganelles` is array all specified organelles by name will be kept.
+ * If `allowedOrganelles` is object their values will also be merged in dna.
+ * If `allowedOrganelles` is missing no organelles will be removed
+ *
+ * @param allowedOrganelles Optional.
+ * @param next
+ */
+test.startServer = function (allowedOrganelles, next) {
+  if (typeof next === 'undefined') {
+    next = allowedOrganelles
+    allowedOrganelles = null
+  }
+
   test.initTestEnv(function (err) {
     if (err) return next(err)
     var cell = variables.cell = new (require('../../server/cell'))()
@@ -41,7 +124,12 @@ test.startServer = function (next) {
       if (err instanceof Error) return next(err)
       next && next()
     })
-    cell.start(function (err) {
+
+    if (allowedOrganelles) {
+      test.variables.dna = removeNotAllowedOrganelles(test.variables.dna, allowedOrganelles)
+    }
+
+    cell.start(test.variables.dna, function (err) {
       if (err) throw err
       // # build server cell
       cell.plasma.emit({type: 'build', branch: 'server.processes.index.plasma'}, function (err) {

--- a/test/server/api/version.test.js
+++ b/test/server/api/version.test.js
@@ -1,7 +1,9 @@
 var request = require('request')
 
 describe('/api/version', function () {
-  before(test.startServer)
+  before((next) => {
+    test.startServer(['organic-api-routes', 'organic-express-server', 'organic-express-response'], next)
+  })
   after(test.stopServer)
 
   it('GET', function (next) {


### PR DESCRIPTION
I wasn't sure if there's something more suitable, or an organic module already available for this, but this works for most of the cases I can think of.

**Here's what it does:**

**Problem:** We don't want all organelles to start every time `startServer` spawns a cell in tests.
**Solution:** The `allowedOrganelles` argument is added to the `startServer` call, to specify which organelles should not be removed. 

(eg. `['organic-mongoose']`)

**Problem:** We also want to be able to extend DNA for a specific organelle (with test-specific values)
**Solution:** In case `allowedOrganelles` is an object, the mentioned organelles config will be merged. 

(eg. `{ 'organic-mongoose': { 'key': 'value' }`)

**Problem:** We don't want to have to put the whole DNA structure in the `startServer` call every time.
**Solution:** `allowedOrganelles` only includes organelles and checks in every process' membrane and plasmas

**Problem:** We don't want to have to mention each organelle we want to remove (as adding new organelles will mean that we have to edit old tests), 
**Solution:** Each non-mentioned organelle will be removed by default.

**Problem:** We might still want an option to run everything
**Solution:** If `allowedOrganelles` is not specified nothing will be changed in the DNA and the cell will be started as it is.